### PR TITLE
Match new d.py requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.3.0,<3.6.0
-websockets>=6.0,<7.0
+websockets>=7.0,<8.0


### PR DESCRIPTION
Change the requirements in requirements.txt to match the ones from the current d.py rewrite version. I've already tested _most_ of the library with WS 7.0 and it shouldn't give any problems.